### PR TITLE
chore: Add installation section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ _A collection of language agnostic tools that facilitate development for the AXI
 - [Preview](#preview)
   - [device-finder](#device-finder)
   - [device-inventory](#device-inventory)
+- [Installation](#installation)
 - [Related projects](#related-projects)
 
 ## Preview
@@ -50,6 +51,17 @@ Options:
       --offline                [env: DEVICE_INVENTORY_OFFLINE=]
   -h, --help                   Print help
 ```
+
+## Installation
+
+The tools in in this project can be installed using Cargo:
+
+```shell
+cargo install --locked --git https://github.com/apljungquist/rs4a.git device-finder
+cargo install --locked --git https://github.com/apljungquist/rs4a.git device-inventory
+```
+
+If you want to install them another way, open an issue and I may be able to help.
 
 ## Related projects
 


### PR DESCRIPTION
Since the tools target ACAP developers in general, not only those using Rust, it may not be immediately obvious how to install the tools. It also may not be convenient to use Cargo, but in that case I don't know what would be convenient, hence the suggestion to open an issue.