### PR TITLE
feat: Add client builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1544,6 +1544,7 @@ name = "rs4a-vapix"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64",
  "log",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ resolver = "2"
 
 [workspace.dependencies]
 anyhow = "1.0.97"
+base64 = "0.22.1"
 clap = "4.5.35"
 clap_complete = "4.5.50"
 dirs = "6.0.0"

--- a/crates/device-finder/src/commands/discover_devices.rs
+++ b/crates/device-finder/src/commands/discover_devices.rs
@@ -135,14 +135,11 @@ pub struct DiscoverDevicesCommand {
 
 async fn probe(host: String, addr: String) -> anyhow::Result<(String, HashMap<String, String>)> {
     let mut details = HashMap::new();
-    let client = rs4a_vapix::Client::detect_scheme(
-        &Host::parse(&addr)?,
-        reqwest::Client::builder()
-            .danger_accept_invalid_certs(true)
-            .build()?,
-    )
-    .await
-    .context("Could not create client")?;
+    let client = rs4a_vapix::Client::builder(Host::parse(&addr)?)
+        .with_inner(|b| b.danger_accept_invalid_certs(true))
+        .build_with_automatic_scheme()
+        .await
+        .context("Could not create client")?;
 
     let SystemreadyData {
         needsetup,

--- a/crates/vapix/Cargo.toml
+++ b/crates/vapix/Cargo.toml
@@ -8,5 +8,6 @@ anyhow = { workspace = true }
 log = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 serde = { workspace = true, features = ["derive"] }
+base64 = { workspace = true }
 serde_json = { workspace = true, features = ["raw_value"] }
 url = { workspace = true }

--- a/crates/vapix/src/client.rs
+++ b/crates/vapix/src/client.rs
@@ -1,5 +1,136 @@
+use std::env;
+
+use anyhow::bail;
+use base64::Engine;
 use log::debug;
+use reqwest::header::{HeaderMap, AUTHORIZATION};
 use url::{Host, Url};
+
+fn authorization_headers(username: &str, password: &str) -> HeaderMap {
+    let credentials = format!("{username}:{password}");
+    let auth_header = format!(
+        "Basic {}",
+        base64::engine::general_purpose::STANDARD.encode(credentials)
+    );
+    let mut headers = HeaderMap::new();
+    headers.insert(AUTHORIZATION, auth_header.try_into().unwrap());
+    headers
+}
+
+pub struct ClientBuilder {
+    host: Host,
+    plain_port: Option<u16>,
+    secure_port: Option<u16>,
+    inner: reqwest::ClientBuilder,
+}
+
+impl ClientBuilder {
+    pub fn new(host: Host) -> Self {
+        Self {
+            host,
+            plain_port: None,
+            secure_port: None,
+            inner: reqwest::Client::builder(),
+        }
+    }
+
+    pub fn from_env() -> anyhow::Result<Self> {
+        let username = env::var("AXIS_DEVICE_USER")?;
+        let password = env::var("AXIS_DEVICE_PASS")?;
+        let host = env::var("AXIS_DEVICE_IP")?;
+        let plain_port = env::var("AXIS_DEVICE_HTTP_PORT")
+            .ok()
+            .map(|p| p.parse())
+            .transpose()?;
+        let secure_port = env::var("AXIS_DEVICE_HTTPS_PORT")
+            .ok()
+            .map(|p| p.parse())
+            .transpose()?;
+        let host = Host::parse(&host)?;
+
+        debug!("Building client using username {username} from env");
+        Ok(ClientBuilder::new(host)
+            .plain_port(plain_port)
+            .secure_port(secure_port)
+            .basic_authentication(&username, &password))
+    }
+
+    pub fn basic_authentication(mut self, username: &str, password: &str) -> Self {
+        let headers = authorization_headers(username, password);
+        self.inner = self.inner.default_headers(headers);
+        self
+    }
+
+    pub fn plain_port(mut self, port: Option<u16>) -> Self {
+        self.plain_port = port;
+        self
+    }
+
+    pub fn secure_port(mut self, port: Option<u16>) -> Self {
+        self.secure_port = port;
+        self
+    }
+
+    pub fn with_inner(
+        mut self,
+        f: impl FnOnce(reqwest::ClientBuilder) -> reqwest::ClientBuilder,
+    ) -> Self {
+        self.inner = f(self.inner);
+        self
+    }
+
+    pub fn build_with_scheme(self, scheme: Scheme) -> anyhow::Result<Client> {
+        let Self {
+            host,
+            plain_port,
+            secure_port,
+            inner,
+        } = self;
+        let client = inner.build()?;
+        let client1 = Client {
+            scheme,
+            host: host.clone(),
+            port: match scheme {
+                Scheme::Secure => secure_port,
+                Scheme::Plain => plain_port,
+            },
+            client,
+        };
+        Ok(client1)
+    }
+
+    /// Automatically select an appropriate scheme and create a new client.
+    pub async fn build_with_automatic_scheme(self) -> anyhow::Result<Client> {
+        let Self {
+            host,
+            plain_port,
+            secure_port,
+            inner,
+        } = self;
+        let client = inner.build()?;
+        let mut candidate = Client {
+            scheme: Scheme::Secure,
+            host,
+            port: None,
+            client,
+        };
+        for (scheme, port) in [(Scheme::Secure, secure_port), (Scheme::Plain, plain_port)] {
+            candidate.scheme = scheme;
+            candidate.port = port;
+            if candidate
+                .system_ready_1()
+                .system_ready()
+                .send()
+                .await
+                .inspect_err(|e| debug!("Could not connect using {} because {e:?}", scheme.http()))
+                .is_ok()
+            {
+                return Ok(candidate);
+            }
+        }
+        bail!("Could not connect to either scheme")
+    }
+}
 
 #[derive(Clone, Copy, Debug)]
 pub enum Scheme {
@@ -24,34 +155,17 @@ impl Scheme {
 pub struct Client {
     scheme: Scheme,
     host: Host,
+    port: Option<u16>,
     client: reqwest::Client,
 }
 
 impl Client {
-    pub fn new(scheme: Scheme, host: Host, client: reqwest::Client) -> Self {
-        Self {
-            scheme,
-            host,
-            client,
-        }
+    pub fn builder(host: Host) -> ClientBuilder {
+        ClientBuilder::new(host)
     }
 
-    /// Automatically select an appropriate scheme and create a new client.
-    pub async fn detect_scheme(host: &Host, client: reqwest::Client) -> Option<Self> {
-        for scheme in [Scheme::Secure, Scheme::Plain] {
-            let candidate = Self::new(scheme, host.clone(), client.clone());
-            if candidate
-                .system_ready_1()
-                .system_ready()
-                .send()
-                .await
-                .inspect_err(|e| debug!("Could not connect using {} because {e:?}", scheme.http()))
-                .is_ok()
-            {
-                return Some(candidate);
-            }
-        }
-        None
+    pub(crate) fn get(&self, path: &str) -> anyhow::Result<reqwest::RequestBuilder> {
+        Ok(self.client.get(self.url().join(path)?))
     }
 
     pub(crate) fn post(&self, path: &str) -> anyhow::Result<reqwest::RequestBuilder> {
@@ -59,9 +173,15 @@ impl Client {
     }
 
     fn url(&self) -> Url {
-        let Self { scheme, host, .. } = self;
+        let Self {
+            scheme, host, port, ..
+        } = self;
         let scheme = scheme.http();
-        Url::parse(&format!("{scheme}://{host}"))
-            .expect("Restricted types are known to combine into a valid URL")
+        if let Some(port) = port {
+            Url::parse(&format!("{scheme}://{host}:{port}"))
+        } else {
+            Url::parse(&format!("{scheme}://{host}"))
+        }
+        .expect("Restricted types are known to combine into a valid URL")
     }
 }

--- a/crates/vapix/src/client.rs
+++ b/crates/vapix/src/client.rs
@@ -164,10 +164,6 @@ impl Client {
         ClientBuilder::new(host)
     }
 
-    pub(crate) fn get(&self, path: &str) -> anyhow::Result<reqwest::RequestBuilder> {
-        Ok(self.client.get(self.url().join(path)?))
-    }
-
     pub(crate) fn post(&self, path: &str) -> anyhow::Result<reqwest::RequestBuilder> {
         Ok(self.client.post(self.url().join(path)?))
     }

--- a/crates/vapix/src/lib.rs
+++ b/crates/vapix/src/lib.rs
@@ -1,6 +1,5 @@
 mod axis_cgi;
 mod client;
 pub mod json_rpc;
-
 pub use axis_cgi::{basic_device_info_1, system_ready_1};
-pub use client::Client;
+pub use client::{Client, ClientBuilder, Scheme};


### PR DESCRIPTION
The main purpose is to make it easier to construct a client when:
- Using local VAPIX as an ACAP app.
- Connecting to a device in development, e.g. when running an ACAP app on host or when running test suites for this library.

---

`crates/vapix/src/client.rs`:
- Expose the internal builder using `with_inner` to allow users to customize the behavior of the reqwest client in ways that are not yet fully supported. This is particularly useful for allowing invalid certs, which I'm not sure if or how to expose. This method also keeps the exposure of the reqwest dependency small, paving the road for supporting other libraries.
- Expose `basic_authentication` even though this could be accomplished using `with_inner` because it is a common configuration that I have no qualms about supporting. Furthermore, if support for digest authentication is added in the future, then customizing the reqwest client will not be enough.
- The `new` and `build_with_scheme` methods take arguments as these are, and will likely remain, mandatory arguments and it is convenient to ensure their presence with the type system.
- One nice feature of the new builder is that most of the setup happens in synchronous code. This makes it easier to build a client when a program starts, possibly before the async runtime is started, and be confident that it happens quickly.
