### PR TITLE
chore: Add smoke tests for VAPIX bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1549,6 +1549,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tokio",
  "url",
 ]
 

--- a/crates/vapix/Cargo.toml
+++ b/crates/vapix/Cargo.toml
@@ -11,3 +11,6 @@ serde = { workspace = true, features = ["derive"] }
 base64 = { workspace = true }
 serde_json = { workspace = true, features = ["raw_value"] }
 url = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros"] }

--- a/crates/vapix/tests/smoke_tests.rs
+++ b/crates/vapix/tests/smoke_tests.rs
@@ -1,0 +1,40 @@
+use std::env;
+
+use rs4a_vapix::{Client, ClientBuilder};
+
+async fn test_client() -> Option<Client> {
+    if env::var_os("AXIS_DEVICE_IP").is_some() {
+        Some(
+            ClientBuilder::from_env()
+                .unwrap()
+                .with_inner(|b| b.danger_accept_invalid_certs(true))
+                .build_with_automatic_scheme()
+                .await
+                .unwrap(),
+        )
+    } else {
+        eprintln!("No device configured, skipping test.");
+        None
+    }
+}
+
+#[tokio::test]
+async fn basic_device_info_get_all_unrestricted_properties_returns_ok() {
+    let Some(client) = test_client().await else {
+        return;
+    };
+    client
+        .basic_device_info_1()
+        .get_all_unrestricted_properties()
+        .send()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn system_ready_system_ready_returns_ok() {
+    let Some(client) = test_client().await else {
+        return;
+    };
+    client.system_ready_1().system_ready().send().await.unwrap();
+}


### PR DESCRIPTION
I try to write code that fails if any assumptions are violated and I experience that regressions oftentimes cause code that should return `Ok` to either return an `Err` or `panic!`. These tests leverage that to achieve a lot of test coverage, cheaply.