### PR TITLE
chore: Add MIT license to all crates

### DIFF
--- a/crates/bin-utils/Cargo.toml
+++ b/crates/bin-utils/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rs4a-bin-utils"
 version = "0.1.0"
 edition.workspace = true
+license = "MIT"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/device-finder/Cargo.toml
+++ b/crates/device-finder/Cargo.toml
@@ -2,6 +2,7 @@
 name = "device-finder"
 version = "0.1.0"
 edition.workspace = true
+license = "MIT"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/device-inventory/Cargo.toml
+++ b/crates/device-inventory/Cargo.toml
@@ -2,6 +2,7 @@
 name = "device-inventory"
 version = "0.1.0"
 edition.workspace = true
+license = "MIT"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/vapix/Cargo.toml
+++ b/crates/vapix/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rs4a-vapix"
 version = "0.1.0"
 edition.workspace = true
+license = "MIT"
 
 [dependencies]
 anyhow = { workspace = true }


### PR DESCRIPTION
Prompted by me trying to use this project from another that checks licenses with `cargo-about`.

MIT is chosen because I want the project to be as useful to others as possible, and that is the least scary license in my experience.