### PR TITLE
fix: Include response text in error

### DIFF
--- a/crates/device-inventory/src/commands/export.rs
+++ b/crates/device-inventory/src/commands/export.rs
@@ -32,6 +32,7 @@ impl ExportCommand {
             warn!("Multiple devices found, using the first one")
         }
 
+        // TODO: Consider `unset`ing variables that are not set.
         let envs = device_inventory::env::envs(&device);
         for (key, value) in envs {
             println!("export {key}={value}");

--- a/crates/vapix/src/json_rpc.rs
+++ b/crates/vapix/src/json_rpc.rs
@@ -25,7 +25,7 @@ where
 {
     let text = text.with_context(|| format!("Could not fetch text, status was {status}"))?;
     let Response { data, error } = serde_json::from_str(&text)
-        .with_context(|| format!("Could not parse response, status was {status}"))?;
+        .with_context(|| format!("Could not parse response; status: {status} text: {text}"))?;
     let data = match (data, error) {
         (Some(d), Some(e)) => {
             debug!("data: {d:?}, error: {e:?}");


### PR DESCRIPTION
This could be a security issue, but until someone informs me that this project is used outside development, I'm OK with taking that risk since it makes debugging the still immature implementations easier.

The new format of the context message is already used in the `rest` and `soap` modules.