### PR TITLE
feat: Decouple transport in JSON RPC style APIs

### DIFF
--- a/crates/device-finder/src/commands/discover_devices.rs
+++ b/crates/device-finder/src/commands/discover_devices.rs
@@ -5,7 +5,10 @@ use futures_util::{pin_mut, stream::StreamExt};
 use itertools::Itertools;
 use log::{debug, error, info, warn};
 use mdns::{RecordKind, Response};
-use rs4a_vapix::{basic_device_info_1::UnrestrictedProperties, system_ready_1::SystemreadyData};
+use rs4a_vapix::{
+    apis, basic_device_info_1::UnrestrictedProperties, json_rpc_http::JsonRpcHttp,
+    system_ready_1::SystemreadyData,
+};
 use tokio::{
     task::JoinSet,
     time::{error::Elapsed, timeout},
@@ -145,7 +148,7 @@ async fn probe(host: String, addr: String) -> anyhow::Result<(String, HashMap<St
         needsetup,
         systemready,
         ..
-    } = client.system_ready_1().system_ready().send().await?;
+    } = apis::system_ready_1::system_ready().send(&client).await?;
     details
         .insert("Need Setup".to_string(), needsetup.to_string())
         .inspect(|_| panic!("Each key is created at most once"));
@@ -162,10 +165,8 @@ async fn probe(host: String, addr: String) -> anyhow::Result<(String, HashMap<St
         serial_number,
         version,
         ..
-    } = client
-        .basic_device_info_1()
-        .get_all_unrestricted_properties()
-        .send()
+    } = apis::basic_device_info_1::get_all_unrestricted_properties()
+        .send(&client)
         .await?
         .property_list;
     details

--- a/crates/vapix/src/apis.rs
+++ b/crates/vapix/src/apis.rs
@@ -1,0 +1,7 @@
+pub mod basic_device_info_1 {
+    pub use crate::basic_device_info_1::get_all_unrestricted_properties;
+}
+
+pub mod system_ready_1 {
+    pub use crate::system_ready_1::system_ready;
+}

--- a/crates/vapix/src/axis_cgi/basic_device_info_1.rs
+++ b/crates/vapix/src/axis_cgi/basic_device_info_1.rs
@@ -3,9 +3,8 @@
 //! [Basic device information]: https://developer.axis.com/vapix/network-video/basic-device-information/
 
 use serde::{Deserialize, Serialize};
-use serde_json::json;
 
-use crate::{client::Client, json_rpc};
+use crate::json_rpc_http::JsonRpcHttp;
 
 #[non_exhaustive]
 #[derive(Debug, Deserialize, Serialize)]
@@ -33,30 +32,27 @@ pub struct UnrestrictedProperties {
     pub web_url: String,
 }
 
-pub struct BasicDeviceInfo1 {
-    client: Client,
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetAllUnrestrictedPropertiesRequest {
+    api_version: &'static str,
+    method: &'static str,
 }
 
-impl BasicDeviceInfo1 {
-    pub fn get_all_unrestricted_properties(
-        self,
-    ) -> json_rpc::RequestBuilder<AllUnrestrictedPropertiesData> {
-        json_rpc::RequestBuilder {
-            client: self.client,
-            path: "axis-cgi/basicdeviceinfo.cgi",
-            json: json!({
-                "method": "getAllUnrestrictedProperties",
-                "apiVersion": "1.0",
-            }),
-            _phantom: Default::default(),
+impl Default for GetAllUnrestrictedPropertiesRequest {
+    fn default() -> Self {
+        Self {
+            api_version: "1.0",
+            method: "getAllUnrestrictedProperties",
         }
     }
 }
 
-impl Client {
-    pub fn basic_device_info_1(&self) -> BasicDeviceInfo1 {
-        BasicDeviceInfo1 {
-            client: self.clone(),
-        }
-    }
+impl JsonRpcHttp for GetAllUnrestrictedPropertiesRequest {
+    type Data = AllUnrestrictedPropertiesData;
+    const PATH: &'static str = "axis-cgi/basicdeviceinfo.cgi";
+}
+
+pub fn get_all_unrestricted_properties() -> GetAllUnrestrictedPropertiesRequest {
+    GetAllUnrestrictedPropertiesRequest::default()
 }

--- a/crates/vapix/src/axis_cgi/basic_device_info_1/get_all_unrestricted_properties_200.json
+++ b/crates/vapix/src/axis_cgi/basic_device_info_1/get_all_unrestricted_properties_200.json
@@ -1,0 +1,18 @@
+{
+  "apiVersion": "1.3",
+  "data": {
+    "propertyList": {
+      "ProdNbr": "M1075-L",
+      "HardwareID": "92A.1",
+      "ProdFullName": "AXIS M1075-L Box Camera",
+      "Version": "12.5.56",
+      "ProdType": "Box Camera",
+      "Brand": "AXIS",
+      "WebURL": "http://www.axis.com",
+      "ProdVariant": "",
+      "SerialNumber": "B8A44F000000",
+      "ProdShortName": "AXIS M1075-L",
+      "BuildDate": "Jun 11 2025 17:32"
+    }
+  }
+}

--- a/crates/vapix/src/axis_cgi/system_ready_1/system_ready_200.json
+++ b/crates/vapix/src/axis_cgi/system_ready_1/system_ready_200.json
@@ -1,0 +1,10 @@
+{
+  "apiVersion": "1.4",
+  "method": "systemready",
+  "data": {
+    "systemready": "yes",
+    "needsetup": "no",
+    "uptime": "37509",
+    "bootid": "a64e48df-6002-4f0a-83a1-98f302b05cb1"
+  }
+}

--- a/crates/vapix/src/client.rs
+++ b/crates/vapix/src/client.rs
@@ -6,6 +6,8 @@ use log::debug;
 use reqwest::header::{HeaderMap, AUTHORIZATION};
 use url::{Host, Url};
 
+use crate::{apis, json_rpc_http::JsonRpcHttp};
+
 fn authorization_headers(username: &str, password: &str) -> HeaderMap {
     let credentials = format!("{username}:{password}");
     let auth_header = format!(
@@ -117,10 +119,9 @@ impl ClientBuilder {
         for (scheme, port) in [(Scheme::Secure, secure_port), (Scheme::Plain, plain_port)] {
             candidate.scheme = scheme;
             candidate.port = port;
-            if candidate
-                .system_ready_1()
-                .system_ready()
-                .send()
+            if apis::system_ready_1::system_ready()
+                .timeout(1)
+                .send(&candidate)
                 .await
                 .inspect_err(|e| debug!("Could not connect using {} because {e:?}", scheme.http()))
                 .is_ok()

--- a/crates/vapix/src/json_rpc.rs
+++ b/crates/vapix/src/json_rpc.rs
@@ -1,13 +1,9 @@
 //! Utilities for working with JSON RPC style APIs.
-use std::marker::PhantomData;
 
-use anyhow::{anyhow, bail, Context};
+use anyhow::{bail, Context};
 use log::debug;
-use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue;
-
-use crate::Client;
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -18,47 +14,33 @@ struct Response<'a> {
     error: Option<&'a RawValue>,
 }
 
-// TODO: Improve error handling
-fn from_response<T>(status: StatusCode, text: reqwest::Result<String>) -> anyhow::Result<T>
-where
-    T: for<'a> Deserialize<'a>,
-{
-    let text = text.with_context(|| format!("Could not fetch text, status was {status}"))?;
-    let Response { data, error } = serde_json::from_str(&text)
-        .with_context(|| format!("Could not parse response; status: {status} text: {text}"))?;
-    let data = match (data, error) {
-        (Some(d), Some(e)) => {
-            debug!("data: {d:?}, error: {e:?}");
-            bail!("Response included data and an error ({e:?})")
+impl<'a> Response<'a> {
+    pub fn try_into_data(self) -> anyhow::Result<Result<&'a RawValue, &'a RawValue>> {
+        let Self { data, error } = self;
+        match (data, error) {
+            (Some(d), Some(e)) => {
+                debug!("data: {d:?}, error: {e:?}");
+                bail!("Response included data and an error ({e:?})")
+            }
+            (Some(d), None) => Ok(Ok(d)),
+            (None, Some(e)) => Ok(Err(e)),
+            (None, None) => bail!("Response included neither data nor error"),
         }
-        (Some(d), None) => d,
-        (None, Some(e)) => bail!("Response included an error ({e:?})"),
-        (None, None) => bail!("Response included neither data nor error"),
-    };
-    serde_json::from_str(data.get()).map_err(|e| anyhow!(e))
-}
-
-pub struct RequestBuilder<T> {
-    pub(crate) client: Client,
-    pub(crate) path: &'static str,
-    pub(crate) json: serde_json::Value,
-    pub(crate) _phantom: PhantomData<T>,
-}
-
-impl<T> RequestBuilder<T>
-where
-    T: for<'a> Deserialize<'a>,
-{
-    pub async fn send(self) -> anyhow::Result<T> {
-        let RequestBuilder {
-            client,
-            path,
-            json,
-            _phantom,
-        } = self;
-        let response = client.post(path)?.json(&json).send().await?;
-        let status = response.status();
-        let text = response.text().await;
-        from_response(status, text)
     }
+}
+
+pub fn parse_data<T>(text: &str) -> anyhow::Result<T>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    let result = serde_json::from_str::<Response>(text)
+        .with_context(|| format!("Could not parse response; status text: {text}"))?
+        .try_into_data()?;
+    let data = match result {
+        Ok(d) => d,
+        // TODO: Proper error
+        Err(e) => bail!("Error: {:?}", e),
+    };
+    serde_json::from_str::<T>(data.get())
+        .with_context(|| format!("Could not parse data: {}", data.get()))
 }

--- a/crates/vapix/src/json_rpc_http.rs
+++ b/crates/vapix/src/json_rpc_http.rs
@@ -1,0 +1,32 @@
+//! Utilities for working with JSON RPC style APIs.
+
+use std::future::Future;
+
+use anyhow::Context;
+use reqwest::StatusCode;
+use serde::{Deserialize, Serialize};
+
+use crate::{json_rpc::parse_data, Client};
+
+fn from_response<T>(status: StatusCode, text: reqwest::Result<String>) -> anyhow::Result<T>
+where
+    T: for<'a> Deserialize<'a>,
+{
+    let text = text.with_context(|| format!("Could not fetch text, status was {status}"))?;
+    parse_data(&text).with_context(|| format!("Could not parse data, status was {status}"))
+}
+
+pub trait JsonRpcHttp: Serialize + Send + Sized {
+    type Data: for<'a> Deserialize<'a>;
+
+    const PATH: &'static str;
+
+    fn send(self, client: &Client) -> impl Future<Output = anyhow::Result<Self::Data>> + Send {
+        async move {
+            let response = client.post(Self::PATH)?.json(&self).send().await?;
+            let status = response.status();
+            let text = response.text().await;
+            from_response(status, text)
+        }
+    }
+}

--- a/crates/vapix/src/lib.rs
+++ b/crates/vapix/src/lib.rs
@@ -1,7 +1,9 @@
+pub mod apis;
 mod axis_cgi;
 mod client;
 mod config;
 pub mod json_rpc;
+pub mod json_rpc_http;
 mod rest;
 mod services;
 pub mod soap;

--- a/crates/vapix/tests/serde.rs
+++ b/crates/vapix/tests/serde.rs
@@ -1,0 +1,21 @@
+use rs4a_vapix::{
+    basic_device_info_1::AllUnrestrictedPropertiesData,
+    json_rpc::parse_data,
+    system_ready_1::{EnglishBoolean, SystemreadyData},
+};
+
+#[test]
+fn can_deserialize_basic_device_info_1_examples() {
+    let text = include_str!(
+        "../src/axis_cgi/basic_device_info_1/get_all_unrestricted_properties_200.json"
+    );
+    let data = parse_data::<AllUnrestrictedPropertiesData>(text).unwrap();
+    assert_eq!(data.property_list.version, "12.5.56");
+}
+
+#[test]
+fn can_deserialize_system_ready_1_examples() {
+    let text = include_str!("../src/axis_cgi/system_ready_1/system_ready_200.json");
+    let data = parse_data::<SystemreadyData>(text).unwrap();
+    assert!(matches!(data.needsetup, EnglishBoolean::No));
+}

--- a/crates/vapix/tests/smoke_tests.rs
+++ b/crates/vapix/tests/smoke_tests.rs
@@ -1,6 +1,6 @@
 use std::{env, ops::Rem, time::SystemTime};
 
-use rs4a_vapix::{Client, ClientBuilder};
+use rs4a_vapix::{apis, json_rpc_http::JsonRpcHttp, Client, ClientBuilder};
 use serde_json::json;
 
 async fn test_client() -> Option<Client> {
@@ -100,10 +100,8 @@ async fn basic_device_info_get_all_unrestricted_properties_returns_ok() {
     let Some(client) = test_client().await else {
         return;
     };
-    client
-        .basic_device_info_1()
-        .get_all_unrestricted_properties()
-        .send()
+    apis::basic_device_info_1::get_all_unrestricted_properties()
+        .send(&client)
         .await
         .unwrap();
 }
@@ -181,5 +179,8 @@ async fn system_ready_system_ready_returns_ok() {
     let Some(client) = test_client().await else {
         return;
     };
-    client.system_ready_1().system_ready().send().await.unwrap();
+    apis::system_ready_1::system_ready()
+        .send(&client)
+        .await
+        .unwrap();
 }


### PR DESCRIPTION
There are two cases where I foresee this being useful:
- The developer wants to send requests over a transport other than HTTP. I think this is unlikely to ever happen for JSON RPC style APIs since new development is mostly using the device configuration framework.
- The developer wishes to use another implementation of the HTTP transport. This is especially relevant in an ACAP context where `reqwest` can be seen as a heavy dependency and lighter options include both slimmer runtime and synchronous implementations, perhaps based on `libcurl`.

Other benefits include:
- Easier and more meaningful to implement `Debug` on requests.

Drawbacks include:
- There's a risk that having more types that implement `serde` traits will bloat binaries.

---

`crates/vapix/src/apis.rs`:
- Re-export only the entry points to make it easy to follow the docs.
- I'm not sure I like having all of these in one file because of contention, but I don't expect much concurrent development and it is less overhead than trying to distribute them in some way.

`crates/vapix/src/axis_cgi/system_ready_1.rs`:
- Add support for the timeout param to test out that the new pattern can be used fluently at least with trivial examples.

`crates/vapix/src/axis_cgi/basic_device_info_1/get_all_unrestricted_properties_200.json`,
`crates/vapix/src/axis_cgi/system_ready_1/system_ready_200.json`:
- These are real examples that have been lightly edited (anonymized for privacy and formatted for readability).
- These are named based on the method and the response, because while working on the services APIs these are the main dimensions that I found. I do however expect that it will become useful to encode product and software version, but trying to anticipate what that will look like is probably not paying off.

`crates/vapix/src/json_rpc.rs`,
`crates/vapix/src/json_rpc_http.rs`:
- I'm not completely happy with the deserialization process, but that seems like an orthogonal change and is left for later.
- I'm not completely happy with the error handling. For instance I want to go back to not including so much in the context and instead use debug logs and/or something `cfg!(debug_assertions)` to make the output more verbose during development. But that too seems orthogonal to the main objective of this commit.

`crates/vapix/tests/serde.rs`:
- Add another integration test for verifying the developer experience when trying to use the text APIs directly. This actually made me realize I had forgotten the `parse_data` function, forcing the user to deal with the envelope explicitly.

