### PR TITLE
fix: Accept empty actions configurations

### DIFF
--- a/crates/vapix/src/services/action1/action_configurations.rs
+++ b/crates/vapix/src/services/action1/action_configurations.rs
@@ -16,6 +16,7 @@ pub struct GetActionConfigurationsResponse {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct ActionConfigurations {
+    #[serde(default)]
     pub action_configuration: Vec<ActionConfiguration>,
 }
 
@@ -46,15 +47,20 @@ pub struct Parameter {
 
 #[cfg(test)]
 mod tests {
-
-    use crate::{
-        services::action1::action_configurations::AddActionConfigurationResponse, soap::parse_soap,
-    };
+    use super::*;
+    use crate::soap::parse_soap;
 
     #[test]
     fn can_deserialize_add_action_configuration_response() {
         let text = include_str!("examples/add_action_configuration_response.xml");
         let data = parse_soap::<AddActionConfigurationResponse>(text).unwrap();
         assert_eq!(1, data.configuration_id);
+    }
+
+    #[test]
+    fn can_deserialize_get_action_configurations_response() {
+        let text = include_str!("examples/get_action_configurations_200_response.xml");
+        let data = parse_soap::<GetActionConfigurationsResponse>(text).unwrap();
+        assert_eq!(0, data.action_configurations.action_configuration.len());
     }
 }

--- a/crates/vapix/src/services/action1/examples/get_action_configurations_200_response.xml
+++ b/crates/vapix/src/services/action1/examples/get_action_configurations_200_response.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://www.w3.org/2003/05/soap-envelope"
+                   xmlns:aa="http://www.axis.com/vapix/ws/action1">
+    <SOAP-ENV:Body>
+        <aa:GetActionConfigurationsResponse>
+            <aa:ActionConfigurations></aa:ActionConfigurations>
+        </aa:GetActionConfigurationsResponse>
+    </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>


### PR DESCRIPTION
I noticed that `get_action_configurations` would fail on a fresh device, despite a 200 status code.

---

`crates/vapix/src/services/action1/examples/get_action_configurations_200_response.xml`:
- A lightly edited version of the response that could not be deserialized (superfluous namespace attributes have been removed for brevity and it has been formatted for readability)