### PR TITLE
feat(vapix)!: Build all XML for `add_action_rule`

### DIFF
--- a/crates/vapix/src/services/action1.rs
+++ b/crates/vapix/src/services/action1.rs
@@ -5,16 +5,21 @@ mod action_configurations;
 mod action_rules;
 
 pub use action_configurations::{AddActionConfigurationResponse, GetActionConfigurationsResponse};
-pub use action_rules::{AddActionRuleResponse, GetActionRulesResponse};
+pub use action_rules::{AddActionRuleResponse, Condition, GetActionRulesResponse};
 
-use crate::{action1::action_configurations::AddActionConfigurationRequest, soap::SimpleRequest};
+use crate::{
+    action1::{
+        action_configurations::AddActionConfigurationRequest, action_rules::AddActionRuleRequest,
+    },
+    soap::SimpleRequest,
+};
 
 pub fn add_action_configuration(template_token: &str) -> AddActionConfigurationRequest {
     AddActionConfigurationRequest::new(template_token)
 }
 
-pub fn add_action_rule() -> SimpleRequest<AddActionRuleResponse> {
-    SimpleRequest::new("http://www.axis.com/vapix/ws/action1", "AddActionRule")
+pub fn add_action_rule(name: String, primary_action: u16) -> AddActionRuleRequest {
+    AddActionRuleRequest::new(name, primary_action)
 }
 
 pub fn get_action_configurations() -> SimpleRequest<GetActionConfigurationsResponse> {

--- a/crates/vapix/src/services/action1/action_rules.rs
+++ b/crates/vapix/src/services/action1/action_rules.rs
@@ -1,5 +1,86 @@
 use serde::Deserialize;
 
+use crate::{
+    soap::SimpleRequest,
+    soap_http::{SoapHttpRequest, SoapRequest},
+};
+
+pub struct AddActionRuleRequest {
+    pub name: String,
+    pub enabled: bool,
+    pub conditions: Conditions,
+    pub primary_action: u16,
+}
+
+impl AddActionRuleRequest {
+    pub(crate) fn new(name: String, primary_action: u16) -> Self {
+        Self {
+            name,
+            enabled: true,
+            conditions: Conditions {
+                condition: Vec::new(),
+            },
+            primary_action,
+        }
+    }
+
+    pub fn enabled(mut self, enabled: bool) -> Self {
+        self.enabled = enabled;
+        self
+    }
+
+    pub fn condition(mut self, condition: Condition) -> Self {
+        self.conditions.condition.push(condition);
+        self
+    }
+}
+
+impl SoapRequest for AddActionRuleRequest {
+    fn to_envelope(self) -> anyhow::Result<String> {
+        let Self {
+            name,
+            enabled,
+            conditions,
+            primary_action,
+        } = self;
+        let mut params = String::new();
+        params.push_str(r#"<NewActionRule xmlns:tns1="http://www.onvif.org/ver10/topics" xmlns:tnsaxis="http://www.axis.com/2009/event/topics">"#);
+        params.push_str(r#"<Name>"#);
+        params.push_str(&name);
+        params.push_str(r#"</Name>"#);
+        params.push_str(r#"<Enabled>"#);
+        params.push_str(&enabled.to_string());
+        params.push_str(r#"</Enabled>"#);
+        params.push_str(r#"<Conditions>"#);
+        for condition in conditions.condition {
+            let Condition {
+                topic_expression,
+                message_content,
+            } = condition;
+            params.push_str(r#"<Condition>"#);
+            params.push_str(r#"<TopicExpression Dialect="http://docs.oasis-open.org/wsn/t-1/TopicExpression/Concrete" xmlns="http://docs.oasis-open.org/wsn/b-2">"#);
+            params.push_str(&topic_expression);
+            params.push_str(r#"</TopicExpression>"#);
+            params.push_str(r#"<MessageContent Dialect="http://www.onvif.org/ver10/tev/messageContentFilter/ItemFilter" xmlns="http://docs.oasis-open.org/wsn/b-2">"#);
+            params.push_str(&message_content);
+            params.push_str(r#"</MessageContent>"#);
+            params.push_str(r#"</Condition>"#);
+        }
+        params.push_str(r#"</Conditions>"#);
+        params.push_str(r#"<PrimaryAction>"#);
+        params.push_str(&primary_action.to_string());
+        params.push_str(r#"</PrimaryAction>"#);
+        params.push_str(r#"</NewActionRule>"#);
+        SimpleRequest::<()>::new("http://www.axis.com/vapix/ws/action1", "AddActionRule")
+            .params(params)
+            .to_envelope()
+    }
+}
+
+impl SoapHttpRequest for AddActionRuleRequest {
+    type Data = AddActionRuleResponse;
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct AddActionRuleResponse {

--- a/crates/vapix/tests/serde.rs
+++ b/crates/vapix/tests/serde.rs
@@ -1,6 +1,6 @@
 use insta::assert_snapshot;
 use rs4a_vapix::{
-    action1::AddActionConfigurationResponse,
+    action1::{AddActionConfigurationResponse, Condition},
     apis,
     basic_device_info_1::AllUnrestrictedPropertiesData,
     json_rpc::parse_data,
@@ -45,7 +45,16 @@ fn can_serialize_action_1_requests() {
             .to_envelope()
             .unwrap()
     );
-    assert_snapshot!(apis::action_1::add_action_rule().to_envelope().unwrap());
+    assert_snapshot!(
+        apis::action_1::add_action_rule("My Action Rule".to_string(), 123)
+            .condition(Condition {
+                topic_expression: "tns1:Device/tnsaxis:Status/SystemReady".to_string(),
+                message_content: r#"boolean(//SimpleItem[@Name="ready" and @Value="1"])"#
+                    .to_string()
+            })
+            .to_envelope()
+            .unwrap()
+    );
     assert_snapshot!(apis::action_1::get_action_configurations()
         .to_envelope()
         .unwrap());

--- a/crates/vapix/tests/smoke_tests.rs
+++ b/crates/vapix/tests/smoke_tests.rs
@@ -1,7 +1,8 @@
 use std::{ops::Rem, time::SystemTime};
 
 use rs4a_vapix::{
-    apis, json_rpc_http::JsonRpcHttp, soap_http::SoapHttpRequest, Client, ClientBuilder,
+    action1::Condition, apis, json_rpc_http::JsonRpcHttp, soap_http::SoapHttpRequest, Client,
+    ClientBuilder,
 };
 use serde_json::json;
 
@@ -58,27 +59,17 @@ async fn action_1_add_and_get_returns_ok() {
             .configuration_id;
 
     let action_rule_name = "smoke test rule";
-    let action_rule_id = apis::action_1::add_action_rule()
-        .params(format!(
-        r#"
-        <NewActionRule xmlns:tns1="http://www.onvif.org/ver10/topics"
-                       xmlns:tnsaxis="http://www.axis.com/2009/event/topics">
-            <Name>{action_rule_name}</Name>
-            <Enabled>true</Enabled>
-            <Conditions>
-                <Condition>
-                    <TopicExpression
-                            Dialect="http://docs.oasis-open.org/wsn/t-1/TopicExpression/Concrete"
-                            xmlns="http://docs.oasis-open.org/wsn/b-2">tns1:Device/tnsaxis:Status/SystemReady</TopicExpression>
-                    <MessageContent
-                            Dialect="http://www.onvif.org/ver10/tev/messageContentFilter/ItemFilter"
-                            xmlns="http://docs.oasis-open.org/wsn/b-2">boolean(//SimpleItem[@Name="ready" and @Value="1"])</MessageContent>
-                </Condition>
-            </Conditions>
-            <PrimaryAction>{action_configuration_id}</PrimaryAction>
-        </NewActionRule>
-        "#
-    )).send(&client).await.unwrap().id;
+    let action_rule_id =
+        apis::action_1::add_action_rule(action_rule_name.to_string(), action_configuration_id)
+            .condition(Condition {
+                topic_expression: "tns1:Device/tnsaxis:Status/SystemReady".to_string(),
+                message_content: r#"boolean(//SimpleItem[@Name="ready" and @Value="1"])"#
+                    .to_string(),
+            })
+            .send(&client)
+            .await
+            .unwrap()
+            .id;
 
     let actions_rules = apis::action_1::get_action_rules()
         .send(&client)

--- a/crates/vapix/tests/snapshots/serde__can_serialize_action_1_requests-2.snap
+++ b/crates/vapix/tests/snapshots/serde__can_serialize_action_1_requests-2.snap
@@ -1,5 +1,5 @@
 ---
 source: crates/vapix/tests/serde.rs
-expression: "apis::action_1::add_action_rule().to_envelope().unwrap()"
+expression: "apis::action_1::add_action_rule(\"My Action Rule\".to_string(),\n123).condition(Condition\n{\n    topic_expression: \"tns1:Device/tnsaxis:Status/SystemReady\".to_string(),\n    message_content:\n    r#\"boolean(//SimpleItem[@Name=\"ready\" and @Value=\"1\"])\"#.to_string()\n}).to_envelope().unwrap()"
 ---
-<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope"><soap:Body><AddActionRule xmlns="http://www.axis.com/vapix/ws/action1"/></soap:Body></soap:Envelope>
+<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope"><soap:Body><AddActionRule xmlns="http://www.axis.com/vapix/ws/action1"><NewActionRule xmlns:tns1="http://www.onvif.org/ver10/topics" xmlns:tnsaxis="http://www.axis.com/2009/event/topics"><Name>My Action Rule</Name><Enabled>true</Enabled><Conditions><Condition><TopicExpression Dialect="http://docs.oasis-open.org/wsn/t-1/TopicExpression/Concrete" xmlns="http://docs.oasis-open.org/wsn/b-2">tns1:Device/tnsaxis:Status/SystemReady</TopicExpression><MessageContent Dialect="http://www.onvif.org/ver10/tev/messageContentFilter/ItemFilter" xmlns="http://docs.oasis-open.org/wsn/b-2">boolean(//SimpleItem[@Name="ready" and @Value="1"])</MessageContent></Condition></Conditions><PrimaryAction>123</PrimaryAction></NewActionRule></AddActionRule></soap:Body></soap:Envelope>


### PR DESCRIPTION
The most difficult thing with using the SOAP style APIs, after properly parsing error responses, is crafting an XML request that the server will accept. As such this API does not make much sense if the user has to craft the part of the request themselves.

One downside is that the new API probably does not support all valid requests that a user may want to send, but considering that I mean for the crate to also provide an API for robust response handling I think falling back on that should be an acceptable fallback.

---

`crates/vapix/src/services/action1/action_rules.rs`:
- Build the XML manually because this is easier in the short term than creating a type that serializes correctly, since the latter still requires a lot of trial and error for me. I am also suspicious of the storage footprint of serde trait implementations and the traits feel even more like a leaky abstraction when working with xml.
- Accept the topic expression and message content as strings because I don't have a good guess for how these would be further decomposed. It would however be nice to provide a builder API for them, too.

`crates/vapix/tests/serde.rs`:
- Update the serde test to create a valid request that exercises more of the API. We know the request is valid because the same request is constructed in the smoke tests.