### PR TITLE
feat: Add public request methods to HTTP client

### DIFF
--- a/crates/vapix/src/client.rs
+++ b/crates/vapix/src/client.rs
@@ -1,7 +1,10 @@
 use anyhow::bail;
 use base64::Engine;
 use log::debug;
-use reqwest::header::{HeaderMap, AUTHORIZATION};
+use reqwest::{
+    header::{HeaderMap, AUTHORIZATION},
+    Method,
+};
 use url::{Host, Url};
 
 use crate::{apis, json_rpc_http::JsonRpcHttp};
@@ -164,12 +167,16 @@ impl Client {
         ClientBuilder::new(host)
     }
 
-    pub(crate) fn get(&self, path: &str) -> anyhow::Result<reqwest::RequestBuilder> {
-        Ok(self.client.get(self.url().join(path)?))
+    pub fn get(&self, path: &str) -> anyhow::Result<reqwest::RequestBuilder> {
+        self.request(Method::GET, path)
     }
 
-    pub(crate) fn post(&self, path: &str) -> anyhow::Result<reqwest::RequestBuilder> {
-        Ok(self.client.post(self.url().join(path)?))
+    pub fn post(&self, path: &str) -> anyhow::Result<reqwest::RequestBuilder> {
+        self.request(Method::POST, path)
+    }
+
+    pub fn request(&self, method: Method, path: &str) -> anyhow::Result<reqwest::RequestBuilder> {
+        Ok(self.client.request(method, self.url().join(path)?))
     }
 
     fn url(&self) -> Url {


### PR DESCRIPTION
The goal is to make it possible to use the client without the rest of this library.

---

`crates/vapix/src/client.rs`:
- Add `request` to make all methods available, without the boilerplate for wrapping each individually.
- Make the existing get and post methods public because they are commonly used.
- Don't add specific methods for any other methods to avoid the boilerplate.