### PR TITLE
chore: Publish rs4a-vapix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ tokio = "1.0.0"
 url = "2.5.4"
 
 rs4a-bin-utils = {path = "crates/bin-utils" }
-rs4a-dut = { path = "crates/dut" }
+rs4a-dut = { version = "0.1", path = "crates/dut" }
 rs4a-vapix = { path = "crates/vapix" }
 
 [workspace.package]

--- a/crates/vapix/Cargo.toml
+++ b/crates/vapix/Cargo.toml
@@ -3,6 +3,7 @@ name = "rs4a-vapix"
 version = "0.1.0"
 edition.workspace = true
 license = "MIT"
+description = "Utilities for working with VAPIX"
 
 [dependencies]
 anyhow = { workspace = true }


### PR DESCRIPTION
To make it easier to depend on and patch.