### PR TITLE
feat(vapix)!: Deserialize systemready properties to bool

### DIFF
--- a/crates/vapix/tests/serde.rs
+++ b/crates/vapix/tests/serde.rs
@@ -9,7 +9,7 @@ use rs4a_vapix::{
     soap::parse_soap,
     soap_http::SoapRequest,
     ssh_1::{AddUserResponse, SetUserResponse},
-    system_ready_1::{EnglishBoolean, SystemreadyData},
+    system_ready_1::SystemreadyData,
 };
 
 #[test]
@@ -52,7 +52,7 @@ fn can_deserialize_ssh_1_error_response() {
 fn can_deserialize_system_ready_1_examples() {
     let text = include_str!("../src/axis_cgi/system_ready_1/system_ready_200.json");
     let data = parse_data::<SystemreadyData>(text).unwrap();
-    assert!(matches!(data.needsetup, EnglishBoolean::No));
+    assert!(!data.needsetup);
 }
 
 #[test]


### PR DESCRIPTION
Prompted by me trying to use the existing API and thinking that it is annoying. I think I had forgotten about the `*_with` attributes when I first wrote this, because the better API is clearly worth the small amount of extra code.